### PR TITLE
Models Feat: Added monster_species and player_monster tables. 

### DIFF
--- a/lib/models/monster_species.py
+++ b/lib/models/monster_species.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, JSON
+from sqlalchemy.orm import relationship
+
+from base import Base
+
+class MonsterSpecies(Base):
+    """
+    1. Why use JSON instead of columsn on base_stats, abilities? 
+        - To achieve one of the bonus challenges.
+    2. base_stats is like: {"hp": 40, "attack": 55, "defence": 50}
+    3. rarity implies a monster being like: common, rare, legendary
+    4. the abilities on JSON can be in an array: ["fireBlast", "wavy"]
+    """
+    __tablename__ = "monster_species"
+    
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(), nullable=False, unique=True)
+    element_type = Column(String(), nullable=False)
+    base_stats = Column(JSON)
+    rarity = Column(String())
+    abilities = Column(JSON)
+    
+    player_monsters = relationship("PlayerMonster", back_populates="monster_species")

--- a/lib/models/player_monster.py
+++ b/lib/models/player_monster.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, ForeignKey, String, JSON
+from sqlalchemy.orm import relationship
+
+from base import Base
+
+class PlayerMonster(Base):
+    """
+    Defaults on expertise and levels: Sets game rules
+        - after catching monster, it will start at level 1
+        - all monsters start with 0 XP and improve with training on battle
+    Base stats in monsterspecies tell us the level that a monster starts with
+        - so, in player_monsters, we will store in current_stats to track the stats' growth
+        - so, stats are only affected on a player perspective.
+    Cascade feat: for data integrity - ensuring that if a monster species
+    no longer exists, then all playermonster entries are also removed.
+    """
+    __tablename__ = "player_monsters"
+    
+    id = Column(Integer(), primary_key=True)
+    nickname = Column(String(), nullable=False, unique=True)
+    level = Column(Integer(), default=1)
+    expertise = Column(Integer(), default=0)
+    current_stats = Column(JSON)
+    
+    species_id = Column(Integer(), ForeignKey("monster_species.id"), nullable=False)
+    player_id = Column(Integer(), ForeignKey("players.id"), nullable=False)
+   
+    monster_species = relationship("MonsterSpecies", back_populates="player_monsters", cascade="all, delete-orphan")


### PR DESCRIPTION
1. Tables creation 
      -  Two models added: monster_species and player_monster
      - Separated concerns: Both models importing Base from base.py to reduce code repetition. 
                - all other models should also follow the same approach.
      - Use of JSON instead of columns
               -  This allows us to meet the bonus challenge in the deliverables
2. Pending tasks:
      -  Add data validation => probably use a helper function, to be defined later in the utilities folder
      - Perform alembic migrations.    